### PR TITLE
Add ZHttpd support

### DIFF
--- a/Formula/czmq.rb
+++ b/Formula/czmq.rb
@@ -21,17 +21,29 @@ class Czmq < Formula
   end
 
   option "with-drafts", "Build and install draft classes and methods"
+  option "with-lz4", "Build with lz4 support"
+  option "with-curl", "Build with libcurl (ZHTTP client) support"
+  option "with-microhttpd", "Build with libmicrohttpd (ZHTTP server) support"
 
   depends_on "asciidoc" => :build
   depends_on "pkg-config" => :build
   depends_on "xmlto" => :build
+
   depends_on "zeromq"
+
+  depends_on "libcurl" if build.with? "curl"
+  depends_on "libmicrohttpd" if build.with? "microhttpd"
+  depends_on "lz4" if build.with? "lz4"
 
   def install
     ENV["XML_CATALOG_FILES"] = "#{etc}/xml/catalog"
 
     args = ["--disable-dependency-tracking", "--prefix=#{prefix}"]
+
     args << "--enable-drafts" if build.with? "drafts"
+    args << "--enable-liblz4" if build.with? "lz4"
+    args << "--enable-libcurl" if build.with? "libcurl"
+    args << "--enable-libmicrohttpd" if build.with? "libmicrohttpd"
 
     system "./autogen.sh" if build.head?
     system "./configure", *args

--- a/Formula/czmq.rb
+++ b/Formula/czmq.rb
@@ -31,7 +31,7 @@ class Czmq < Formula
 
   depends_on "zeromq"
 
-  depends_on "libcurl" if build.with? "curl"
+  depends_on "curl" if build.with? "curl"
   depends_on "libmicrohttpd" if build.with? "microhttpd"
   depends_on "lz4" if build.with? "lz4"
 


### PR DESCRIPTION
The newest version of czmq supports [ZHTTP](https://rfc.zeromq.org/spec:33/ZHTTP/) via an agent running a mongrel2-like http appserver. This adds support for that API.